### PR TITLE
Add block storage and ssh key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This guide will show you how to programmatically use the 1&amp;1 library to perf
   - [Creating a Load Balancer](#creating-a-load-balancer)
   - [Creating a Monitoring Policy](#creating-a-monitoring-policy)
   - [Creating a Block Storage](#creating-a-block-storage)
+  - [Creating an SSH Key](#creating-an-ssh-key)
   - [Updating Server Cores, Memory, and Disk](#updating-server-cores-memory-and-disk)
   - [Listing Servers, Images, Shared Storages, and More](#listing-servers-images-shared-storages-and-more )
 - [Example App](#example-app)
@@ -401,7 +402,7 @@ $client = new OneAndOne('<API-TOKEN>');
 // Instantiate Block Storage Object
 $block_storage = $client->blockStorage();
 
-// Create Load Balancer
+// Create Block Storage
 $args = [
     'name' => 'My new block storage',
     'description' => 'My block storage description',
@@ -412,6 +413,35 @@ $args = [
 
 // Perform Request
 $res = $block_storage->create($args);
+echo json_encode($res, JSON_PRETTY_PRINT);
+```
+
+
+### Creating an SSH Key
+
+```php
+<?php
+
+require(__DIR__.'/vendor/autoload.php');
+
+use src\oneandone\OneAndOne;
+
+// Instantiate library with your API Token
+$client = new OneAndOne('<API-TOKEN>');
+
+
+// Instantiate SshKey Object
+$ssh_key = $client->sshKey();
+
+// Create SSH Key
+$args = [
+    'name' => 'Test SSH Key',
+    'description' => 'Test description',
+    'public_key' => '<PUBLIC-KEY>'
+];
+
+// Perform Request
+$res = $ssh_key->create($args);
 echo json_encode($res, JSON_PRETTY_PRINT);
 ```
 
@@ -528,6 +558,13 @@ echo json_encode($res, JSON_PRETTY_PRINT);
 $block_storage = $client->blockStorage();
 
 $res = $block_storage->all();
+echo json_encode($res, JSON_PRETTY_PRINT);
+
+
+# List all ssh keys on your account
+$ssh_key = $client->sshKey();
+
+$res = $ssh_key->all();
 echo json_encode($res, JSON_PRETTY_PRINT);
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This guide will show you how to programmatically use the 1&amp;1 library to perf
   - [Creating a Firewall Policy](#creating-a-firewall-policy)
   - [Creating a Load Balancer](#creating-a-load-balancer)
   - [Creating a Monitoring Policy](#creating-a-monitoring-policy)
+  - [Creating a Block Storage](#creating-a-block-storage)
   - [Updating Server Cores, Memory, and Disk](#updating-server-cores-memory-and-disk)
   - [Listing Servers, Images, Shared Storages, and More](#listing-servers-images-shared-storages-and-more )
 - [Example App](#example-app)
@@ -384,6 +385,37 @@ echo json_encode($res, JSON_PRETTY_PRINT);
 ```
 
 
+### Creating a Block Storage
+
+```php
+<?php
+
+require(__DIR__.'/vendor/autoload.php');
+
+use src\oneandone\OneAndOne;
+
+// Instantiate library with your API Token
+$client = new OneAndOne('<API-TOKEN>');
+
+
+// Instantiate Block Storage Object
+$block_storage = $client->blockStorage();
+
+// Create Load Balancer
+$args = [
+    'name' => 'My new block storage',
+    'description' => 'My block storage description',
+    'size' => 40,
+    'server' => '<SERVER-ID>',
+    'datacenter_id' => '<DATACENTER-ID>'
+];
+
+// Perform Request
+$res = $block_storage->create($args);
+echo json_encode($res, JSON_PRETTY_PRINT);
+```
+
+
 ### Updating Server Cores, Memory, and Disk
 
 1&amp;1 allows users to dynamically update cores, memory, and disk independently of each other. This removes the restriction of needing to upgrade to the next size up to receive an increase in memory. You can now simply increase the instances memory keeping your costs in-line with your resource needs.
@@ -490,6 +522,13 @@ $image = $client->image();
 
 $res = $image->all();
 echo json_encode($res, JSON_PRETTY_PRINT);
+
+
+# List all block storages on your account
+$block_storage = $client->blockStorage();
+
+$res = $block_storage->all();
+echo json_encode($res, JSON_PRETTY_PRINT);
 ```
 
 
@@ -584,6 +623,24 @@ echo $server->waitFor();
 
 
 
+// Create Block Storage
+$block_storage = $client->blockStorage();
+
+$my_block_storage = [
+    'name' => 'My new block storage',
+    'description' => 'My block storage description',
+    'size' => 40,
+    'server' => $server->id,
+    'datacenter_id' => $server->specs['datacenter_id']
+];
+
+echo "\nCreating block storage...\n";
+$res = $block_storage->create($my_block_storage);
+// Wait for Block Storage to be ready
+echo $block_storage->waitFor();
+
+
+
 // Add the Load Balancer to the New IP
 $add_lb = [
     'ip_id' => $server->first_ip['id'],
@@ -613,6 +670,10 @@ echo $server->waitFor();
 // Cleanup
 echo "\nEverything looks good!\n";
 echo "\nLet's clean up the mess we just made.\n";
+
+echo "\nDeleting block storage...\n";
+$block_storage->delete();
+echo "Success!\n";
 
 echo "\nDeleting server...\n";
 $server->delete();

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -26,6 +26,7 @@
 - [VPN's](#vpn)
 - [Roles](#roles)
 - [Block Storages](#block-storages)
+- [SSH Keys](#ssh-keys)
 
 
 
@@ -2766,4 +2767,75 @@ $res = $block_storage->detachBlockStorage();
 OR
 
 $res = $block_storage->detachBlockStorage('<BLOCK-STORAGE-ID>');
+```
+
+
+
+# <a name="ssh-keys"></a>SSH Keys
+
+Get started by instantiating an `SshKey` object:
+
+```
+$client = new OneAndOne('<API-TOKEN>');
+
+$ssh_key = $client->sshKey();
+```
+
+
+
+**List all SSH Keys:**
+
+```
+$res = $ssh_key->all();
+```
+
+
+**Retrieve a single SSH Key:**
+
+```
+$res = $ssh_key->get();
+
+OR
+
+$res = $ssh_key->get('<SSH-KEY-ID>');
+```
+
+
+**Create an SSH Key:**
+
+```
+$args = [
+    'name' => 'Example SSH Key',
+    'description' => 'Test Description',
+    'public_key' => '<PUBLIC-KEY>'
+];
+
+$res = $ssh_key->create($args);
+```
+
+
+**Modify an SSH Key:**
+
+```
+$args = [
+    'name' => 'New Name',
+    'description' => 'New Description'
+];
+
+$res = $vpn->modify($args);
+
+OR
+
+$res = $ssh_key->modify($args, '<VPN-ID>');
+```
+
+
+**Delete an SSH Key:**
+
+```
+$res = $ssh_key->delete();
+
+OR
+
+$res = $ssh_key->delete('<SSH-KEY-ID>');
 ```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -25,6 +25,7 @@
 - [Ping Auth](#ping-auth)
 - [VPN's](#vpn)
 - [Roles](#roles)
+- [Block Storages](#block-storages)
 
 
 
@@ -2670,4 +2671,99 @@ $res = $role->clone($name);
 OR
 
 $res = $role->clone($name, '<ROLE-ID>');
+```
+
+
+
+
+# <a name="block-storages"></a>Block Storages
+
+Get started by instantiating a `BlockStorage` object:
+
+```
+$client = new OneAndOne('<API-TOKEN>');
+
+$block_storage = $client->blockStorage();
+```
+
+**List all block storages:**
+
+```
+$res = $block_storage->all();
+```
+
+
+**Returns information about a block storage:**
+
+```
+$res = $block_storage->get();
+
+OR
+
+$res = $block_storage->get('<BLOCK-STORAGE-ID>');
+```
+
+
+**Create a block storage:**
+
+*Note:* `size` must be a multiple of `10`
+
+```
+$args = [
+    'name' => 'Test Block Storage',
+    'description' => 'Test Desc',
+    'size' => 40,
+    'datacenter_id' => '<DATACENTER-ID>'
+];
+
+$res = $block_storage->create($args);
+```
+
+
+**Attach block storage to a server:**
+
+```
+$res = $block_storage->attachBlockStorage('<SERVER-ID>');
+
+OR
+
+$res = $block_storage->attachBlockStorage('<SERVER-ID>', '<BLOCK-STORAGE-ID>');
+```
+
+
+**Modify a block storage:**
+
+```
+$args = [
+    'name' => 'New Name',
+    'description' => 'New Desc',
+];
+
+$res = $block_storage->modify($args);
+
+OR
+
+$res = $block_storage->modify($args, '<BLOCK-STORAGE-ID>');
+```
+
+
+**Delete a block storage:**
+
+```
+$res = $block_storage->delete();
+
+OR
+
+$res = $block_storage->delete('<BLOCK-STORAGE-ID>');
+```
+
+
+**Detach storage from a server:**
+
+```
+$res = $block_storage->detachBlockStorage();
+
+OR
+
+$res = $block_storage->detachBlockStorage('<BLOCK-STORAGE-ID>');
 ```

--- a/examples/block_storage_examples.php
+++ b/examples/block_storage_examples.php
@@ -1,0 +1,63 @@
+<?php
+
+require(__DIR__.'/vendor/autoload.php');
+
+use src\oneandone\OneAndOne;
+
+$client = new OneAndOne('<API-TOKEN>');
+
+$block_storage = $client->blockStorage();
+
+
+
+# Create a block storage
+$args = [
+    'name' => 'My new block storage',
+    'description' => 'My block storage description',
+    'size' => 40,
+    'datacenter_id' => '<DATACENTER-ID>'
+];
+
+$res = $block_storage->create($args);
+echo json_encode($res, JSON_PRETTY_PRINT);
+
+
+
+# List all block storages on your account
+$res = $block_storage->all();
+echo json_encode($res, JSON_PRETTY_PRINT);
+
+
+
+# Retrieve a block storage's current specs
+$res = $block_storage->get('<BLOCK-STORAGE-ID>');
+echo json_encode($res, JSON_PRETTY_PRINT);
+
+
+
+# Modify a block storage
+$args = [
+    'name' => 'New Name',
+    'description' => 'New Desc'
+];
+
+$res = $block_storage->modify($args, '<BLOCK-STORAGE-ID>');
+echo json_encode($res, JSON_PRETTY_PRINT);
+
+
+
+# Attach block storage to a server
+$res = $block_storage->attachBlockStorage('<SERVER-ID>', '<BLOCK-STORAGE-ID>');
+echo json_encode($res, JSON_PRETTY_PRINT);
+
+
+
+# Detach block storage from a server
+$res = $block_storage->detachBlockStorage('<BLOCK-STORAGE-ID>');
+echo json_encode($res, JSON_PRETTY_PRINT);
+
+
+
+# Delete a block storage
+$res = $block_storage->delete('<BLOCK-STORAGE-ID>');
+echo json_encode($res, JSON_PRETTY_PRINT);

--- a/src/oneandone.php
+++ b/src/oneandone.php
@@ -25,6 +25,7 @@ use src\oneandone\PingAuth;
 use src\oneandone\Vpn;
 use src\oneandone\Role;
 use src\oneandone\BlockStorage;
+use src\oneandone\SshKey;
 
 // Include Library Classes/Traits
 require(dirname(__DIR__).'/vendor/autoload.php');
@@ -50,6 +51,7 @@ require 'oneandone/ping_auth.php';
 require 'oneandone/vpn.php';
 require 'oneandone/role.php';
 require 'oneandone/block_storage.php';
+require 'oneandone/ssh_key.php';
 
 // Module Global Constants
 define('BASE_URL', 'https://cloudpanel-api.1and1.com');
@@ -221,6 +223,13 @@ class OneAndOne {
     public function blockStorage() {
 
         return new BlockStorage($this->api_token, $this->header);
+
+    }
+
+    // SSH Key Class Init
+    public function sshKey() {
+
+        return new SshKey($this->api_token, $this->header);
 
     }
     

--- a/src/oneandone.php
+++ b/src/oneandone.php
@@ -24,6 +24,7 @@ use src\oneandone\Ping;
 use src\oneandone\PingAuth;
 use src\oneandone\Vpn;
 use src\oneandone\Role;
+use src\oneandone\BlockStorage;
 
 // Include Library Classes/Traits
 require(dirname(__DIR__).'/vendor/autoload.php');
@@ -48,6 +49,7 @@ require 'oneandone/ping.php';
 require 'oneandone/ping_auth.php';
 require 'oneandone/vpn.php';
 require 'oneandone/role.php';
+require 'oneandone/block_storage.php';
 
 // Module Global Constants
 define('BASE_URL', 'https://cloudpanel-api.1and1.com');
@@ -212,6 +214,13 @@ class OneAndOne {
     public function role() {
 
         return new Role($this->api_token, $this->header);
+
+    }
+
+    // Block Storage Class Init
+    public function blockStorage() {
+
+        return new BlockStorage($this->api_token, $this->header);
 
     }
     

--- a/src/oneandone/block_storage.php
+++ b/src/oneandone/block_storage.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace src\oneandone;
+
+use Requests;
+
+class BlockStorage {
+
+    protected $api_token;
+    protected $header;
+    public $id;
+    public $specs;
+    const BASE_ENDPOINT = '/block_storages';
+
+    // Constructor
+    public function __construct($token, $header) {
+
+        $this->api_token = $token;
+        $this->header = $header;
+
+    }
+
+    // Block Storage methods
+    public function all($params = []) {
+
+        // Build query parameter object
+        $params += [
+            'page' => null,
+            'per_page' => null,
+            'sort' => null,
+            'q' => null,
+            'fields' => null
+        ];
+
+        // Build URL
+        $url = Utilities::buildURL(self::BASE_ENDPOINT, null, $params);
+
+        // Perform Request
+        $response = Requests::get($url, $this->header);
+
+        // Check response status
+        Utilities::checkResponse($response->body, $response->status_code);
+
+        // Decode the response and return
+        return json_decode($response->body, true);
+
+    }
+
+    public function create($args) {
+
+        // Build POST body
+        $args += [
+            'name' => null,
+            'description' => null,
+            'size' => null,
+            'server' => null,
+            'datacenter_id' => null
+        ];
+
+        // Clean out null values from POST body
+        $body = Utilities::cleanArray($args);
+
+        // Encode the POST body
+        $data = json_encode($body);
+
+        // Build URL
+        $url = Utilities::buildURL(self::BASE_ENDPOINT);
+
+        // Perform Request
+        $response = Requests::post($url, $this->header, $data);
+
+        // Check response status
+        Utilities::checkResponse($response->body, $response->status_code);
+
+        // Decode the response
+        $json = json_decode($response->body, true);
+
+        // Store block storage ID and response body for later use
+        $this->specs = $json;
+        $this->id = $json['id'];
+
+        return $json;
+
+    }
+
+    public function get($block_storage_id = null) {
+
+        // Build URI
+        if($block_storage_id) {
+            $uri = $block_storage_id;
+        }else{
+            $uri = $this->id;
+        }
+
+        // Build URL
+        $extension = "/$uri";
+        $url = Utilities::buildURL(self::BASE_ENDPOINT, $extension);
+
+        // Perform Request
+        $response = Requests::get($url, $this->header);
+
+        // Check response status
+        Utilities::checkResponse($response->body, $response->status_code);
+
+        // Decode the response and return
+        return json_decode($response->body, true);
+
+    }
+
+    public function modify($args, $block_storage_id = null) {
+
+        // Build URI
+        if($block_storage_id) {
+            $uri = $block_storage_id;
+        }else{
+            $uri = $this->id;
+        }
+
+        // Build PUT body
+        $args += [
+            'name' => null,
+            'description' => null
+        ];
+
+        // Clean out null values from PUT body
+        $body = Utilities::cleanArray($args);
+
+        // Encode the PUT body
+        $data = json_encode($body);
+
+        // Build URL
+        $extension = "/$uri";
+        $url = Utilities::buildURL(self::BASE_ENDPOINT, $extension);
+
+        // Perform Request
+        $response = Requests::put($url, $this->header, $data);
+
+        // Check response status
+        Utilities::checkResponse($response->body, $response->status_code);
+
+        // Decode the response
+        return json_decode($response->body, true);
+
+    }
+
+    public function delete($block_storage_id = null) {
+
+        // Build URI
+        if($block_storage_id) {
+            $uri = $block_storage_id;
+        }else{
+            $uri = $this->id;
+        }
+
+        // Build URL
+        $extension = "/$uri";
+        $url = Utilities::buildURL(self::BASE_ENDPOINT, $extension);
+
+        // Perform Request
+        $response = Requests::delete($url, $this->header);
+
+        // Check response status
+        Utilities::checkResponse($response->body, $response->status_code);
+
+        // Decode the response and return
+        return json_decode($response->body, true);
+
+    }
+
+    public function attachBlockStorage($server_id, $block_storage_id = null) {
+
+        // Build URI
+        if($block_storage_id) {
+            $uri = $block_storage_id;
+        }else{
+            $uri = $this->id;
+        }
+
+        // Build POST body
+        $body = [
+            'server_id' => $server_id
+        ];
+
+        // Encode the POST body
+        $data = json_encode($body);
+
+        // Build URL
+        $extension = "/$uri/server";
+        $url = Utilities::buildURL(self::BASE_ENDPOINT, $extension);
+
+        // Perform Request
+        $response = Requests::post($url, $this->header, $data);
+
+        // Check response status
+        Utilities::checkResponse($response->body, $response->status_code);
+
+        // Decode the response and return
+        return json_decode($response->body, true);
+
+    }
+
+    public function detachBlockStorage($block_storage_id = null) {
+
+        // Build URI
+        if($block_storage_id) {
+            $uri = $block_storage_id;
+        }else{
+            $uri = $this->id;
+        }
+
+        // Build URL
+        $extension = "/$uri/server";
+        $url = Utilities::buildURL(self::BASE_ENDPOINT, $extension);
+
+        // Perform Request
+        $response = Requests::delete($url, $this->header);
+
+        // Check response status
+        Utilities::checkResponse($response->body, $response->status_code);
+
+        // Decode the response and return
+        return json_decode($response->body, true);
+
+    }
+
+    public function waitFor($timeout = 25, $interval = 15) {
+
+        // Set counter for timeout
+        $counter = 0;
+
+        // Check initial status and save block storage state
+        $initial_response = $this->get();
+        $block_storage_state = $initial_response['state'];
+
+        // Keep polling the server's state until good
+        while(!in_array($block_storage_state, GOOD_STATES)) {
+
+            // Wait interval in seconds before polling again
+            sleep($interval);
+
+            // Check block storage state again
+            $current_response = $this->get();
+            $block_storage_state = $current_response['state'];
+
+            // Iterate counter and check for timeout
+            $counter++;
+            if($counter == $timeout) {
+                echo "The operation timed out after $timeout minutes.\n";
+                break;
+            }
+
+        }
+
+        return "duration => $counter";
+
+    }
+
+}

--- a/src/oneandone/image.php
+++ b/src/oneandone/image.php
@@ -54,7 +54,11 @@ class Image {
             'name' => null,
             'description' => null,
             'frequency' => null,
-            'num_images' => null
+            'num_images' => null,
+            'source' => null,
+            'url' => null,
+            'os_id' => null,
+            'type' => null,
         ];
 
         // Encode the POST body

--- a/src/oneandone/server.php
+++ b/src/oneandone/server.php
@@ -69,7 +69,8 @@ class Server {
             'load_balancer_id' => null,
             'monitoring_policy_id' => null,
             'rsa_key' => null,
-            'datacenter_id' => null
+            'datacenter_id' => null,
+            'public_key' => null
         ];
 
         // Clean out null values from POST body

--- a/src/oneandone/ssh_key.php
+++ b/src/oneandone/ssh_key.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace src\oneandone;
+
+use Requests;
+
+class SshKey {
+
+    protected $api_token;
+    protected $header;
+    public $id;
+    public $specs;
+    const BASE_ENDPOINT = '/ssh_keys';
+
+    // Constructor
+    public function __construct($token, $header) {
+
+        $this->api_token = $token;
+        $this->header = $header;
+
+    }
+
+    // SSH Key methods
+    public function all($params = []) {
+
+        // Build query parameter object
+        $params += [
+            'page' => null,
+            'per_page' => null,
+            'sort' => null,
+            'q' => null,
+            'fields' => null
+        ];
+
+        // Build URL
+        $url = Utilities::buildURL(self::BASE_ENDPOINT, null, $params);
+
+        // Perform Request
+        $response = Requests::get($url, $this->header);
+
+        // Check response status
+        Utilities::checkResponse($response->body, $response->status_code);
+
+        // Decode the response and return
+        return json_decode($response->body, true);
+
+    }
+
+    public function create($args) {
+
+        // Build POST body
+        $args += [
+            'name' => null,
+            'description' => null,
+            'public_key' => null
+        ];
+
+        // Encode the POST body
+        $data = json_encode($args);
+
+        // Build URL
+        $url = Utilities::buildURL(self::BASE_ENDPOINT);
+
+        // Perform Request
+        $response = Requests::post($url, $this->header, $data);
+
+        // Check response status
+        Utilities::checkResponse($response->body, $response->status_code);
+
+        // Decode the response
+        $json = json_decode($response->body, true);
+
+        // Store image ID and response body for later use
+        $this->specs = $json;
+        $this->id = $json['id'];
+
+        return $json;
+
+    }
+
+    public function get($ssh_key_id = null) {
+
+        // Build URI
+        if($ssh_key_id) {
+            $uri = $ssh_key_id;
+        }else{
+            $uri = $this->id;
+        }
+
+        // Build URL
+        $extension = "/$uri";
+        $url = Utilities::buildURL(self::BASE_ENDPOINT, $extension);
+
+        // Perform Request
+        $response = Requests::get($url, $this->header);
+
+        // Check response status
+        Utilities::checkResponse($response->body, $response->status_code);
+
+        // Decode the response and return
+        return json_decode($response->body, true);
+
+    }
+
+    public function modify($args, $ssh_key_id = null) {
+
+        // Build URI
+        if($ssh_key_id) {
+            $uri = $ssh_key_id;
+        }else{
+            $uri = $this->id;
+        }
+
+        // Build PUT body
+        $args += [
+            'name' => null,
+            'description' => null
+        ];
+
+        // Clean out null values from PUT body
+        $body = Utilities::cleanArray($args);
+
+        // Encode the PUT body
+        $data = json_encode($body);
+
+        // Build URL
+        $extension = "/$uri";
+        $url = Utilities::buildURL(self::BASE_ENDPOINT, $extension);
+
+        // Perform Request
+        $response = Requests::put($url, $this->header, $data);
+
+        // Check response status
+        Utilities::checkResponse($response->body, $response->status_code);
+
+        // Decode the response and return
+        return json_decode($response->body, true);
+
+    }
+
+
+    public function delete($ssh_key_id = null) {
+
+        // Build URI
+        if($ssh_key_id) {
+            $uri = $ssh_key_id;
+        }else{
+            $uri = $this->id;
+        }
+
+        // Build URL
+        $extension = "/$uri";
+        $url = Utilities::buildURL(self::BASE_ENDPOINT, $extension);
+
+        // Perform Request
+        $response = Requests::delete($url, $this->header);
+
+        // Check response status
+        Utilities::checkResponse($response->body, $response->status_code);
+
+        // Decode the response and return
+        return json_decode($response->body, true);
+
+    }
+
+
+    public function waitFor($timeout = 25, $interval = 15) {
+
+        // Set counter for timeout
+        $counter = 0;
+
+        // Check initial status and save ssh key state
+        $initial_response = $this->get();
+        $ssh_key_state = $initial_response['state'];
+
+        // Keep polling the ssh key's state until good
+        while(!in_array($ssh_key_state, GOOD_STATES)) {
+
+            // Wait interval in seconds before polling again
+            sleep($interval);
+
+            // Check ssh key state again
+            $current_response = $this->get();
+            $ssh_key_state = $current_response['state'];
+
+            // Iterate counter and check for timeout
+            $counter++;
+            if($counter == $timeout) {
+                echo "The operation timed out after $timeout minutes.\n";
+                break;
+            }
+
+        }
+
+        return "duration => $counter";
+
+    }
+
+}

--- a/tests/blockstoragemock.php
+++ b/tests/blockstoragemock.php
@@ -1,0 +1,158 @@
+<?php
+
+require_once(dirname(__DIR__).'/src/oneandone/block_storage.php');
+
+class BlockStorageTest extends PHPUnit_Framework_TestCase
+{
+
+    public function setup() {
+
+        $this->stub = $this->getMockBuilder('src\oneandone\BlockStorage')
+                           ->disableOriginalConstructor()
+                           ->getMock();
+
+    }
+
+    public function testAll() {
+
+        // Read mock JSON data
+        $file = file_get_contents('tests/mock-api/list-block-storages.json');
+        $data = json_decode($file, true);
+
+        // Create stub
+        $this->stub->method('all')
+             ->willReturn($data);
+
+        // Perform call
+        $res = $this->stub->all();
+
+        // Assert
+        $this->assertEquals($res[0]['id'], '6AD2F180B7B666539EF75A02FE227084');
+
+    }
+
+    public function testCreate() {
+
+        // Read mock JSON data
+        $file = file_get_contents('tests/mock-api/create-block-storage.json');
+        $data = json_decode($file, true);
+
+        // Create stub
+        $this->stub->method('create')
+             ->willReturn($data);
+
+        // Perform call
+        $args = [
+            'name' => 'My block storage 4',
+            'description' => 'My block storage description',
+            'size' => 200
+        ];
+
+        $res = $this->stub->create($args);
+
+        // Assert
+        $this->assertEquals($res['id'], '6AD2F180B7B666539EF75A02FE227084');
+
+    }
+
+    public function testGet() {
+
+        // Read mock JSON data
+        $file = file_get_contents('tests/mock-api/get-block-storage.json');
+        $data = json_decode($file, true);
+
+        // Create stub
+        $this->stub->method('get')
+             ->willReturn($data);
+
+        // Perform call
+        $res = $this->stub->get('6AD2F180B7B666539EF75A02FE227084');
+
+        // Assert
+        $this->assertEquals($res['id'], '6AD2F180B7B666539EF75A02FE227084');
+
+    }
+
+    public function testModify() {
+
+        // Read mock JSON data
+        $file = file_get_contents('tests/mock-api/modify-storage.json');
+        $data = json_decode($file, true);
+
+        // Create stub
+        $this->stub->method('modify')
+             ->willReturn($data);
+
+        // Perform call
+        $args = [
+            'name' => 'New Name',
+            'description' => 'New Desc'
+        ];
+
+        $res = $this->stub->modify($args);
+
+        // Assert
+        $this->assertEquals($res['size'], 200);
+
+    }
+
+    public function testDelete() {
+
+        // Read mock JSON data
+        $file = file_get_contents('tests/mock-api/delete-block-storage.json');
+        $data = json_decode($file, true);
+
+        // Create stub
+        $this->stub->method('delete')
+             ->willReturn($data);
+
+        // Perform call
+        $res = $this->stub->delete('6AD2F180B7B666539EF75A02FE227084');
+
+        // Assert
+        $this->assertEquals($res['state'], 'REMOVING');
+
+    }
+
+    public function testAttachBlockStorage() {
+
+        // Read mock JSON data
+        $file = file_get_contents('tests/mock-api/attach-block-storage.json');
+        $data = json_decode($file, true);
+
+        // Create stub
+        $this->stub->method('attachBlockStorage')
+            ->willReturn($data);
+
+        // Perform call
+        $res = $this->stub->addServers('638ED28205B1AFD7ADEF569C725DD85F',
+            '6AD2F180B7B666539EF75A02FE227084');
+
+        // Assert
+        $this->assertEquals($res['server']['id'],
+            '638ED28205B1AFD7ADEF569C725DD85F');
+
+    }
+
+    public function testDetachBlockStorage() {
+
+        // Read mock JSON data
+        $file = file_get_contents('tests/mock-api/detach-block-storage.json');
+        $data = json_decode($file, true);
+
+        // Create stub
+        $this->stub->method('detachBlockStorage')
+             ->willReturn($data);
+
+        // Perform call
+        $server_id = '<SERVER-ID>';
+
+        $res = $this->stub->detachBlockStorage('6AD2F180B7B666539EF75A02FE227084');
+
+        // Assert
+        $this->assertEquals($res['id'], '6AD2F180B7B666539EF75A02FE227084');
+        $this->assertEquals($res['state'], 'CONFIGURING');
+
+    }
+
+}

--- a/tests/mock-api/attach-block-storage.json
+++ b/tests/mock-api/attach-block-storage.json
@@ -1,0 +1,18 @@
+{
+  "id": "6AD2F180B7B666539EF75A02FE227084",
+  "size": 200,
+  "state": "ACTIVE",
+  "description": "My block storage for containers",
+  "datacenter": {
+    "id": "D0F6D8C8ED29D3036F94C27BBB7BAD36",
+    "location": "USA",
+    "country_code": "US"
+  },    
+  "name": "My block storage 1",
+  "creation_date": "2015-05-06T08:33:25+00:00",
+  "server":
+  {
+    "id": "638ED28205B1AFD7ADEF569C725DD85F",
+    "name": "My server 1"    
+  }  
+}

--- a/tests/mock-api/create-block-storage.json
+++ b/tests/mock-api/create-block-storage.json
@@ -1,0 +1,14 @@
+{
+  "id": "6AD2F180B7B666539EF75A02FE227084",
+  "size": 200,
+  "state": "CONFIGURING",
+  "description": "My block storage description",
+  "datacenter": {
+    "id": "D0F6D8C8ED29D3036F94C27BBB7BAD36",
+    "location": "USA",
+    "country_code": "US"
+  },
+  "name": "My block storage 4",
+  "creation_date": "2015-05-06T08:33:25+00:00",
+  "server": null
+}

--- a/tests/mock-api/create-ssh-key.json
+++ b/tests/mock-api/create-ssh-key.json
@@ -1,0 +1,10 @@
+{
+  "id": "39AA65F5D5B02FA02D58173094EBAF95",
+  "name": "My SSH key 1",
+  "description": "My SSH key description",
+  "state": "ACTIVE",
+  "servers": [],
+  "md5": "5df9f63916ebf8528697b629022993e8",
+  "public_key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUpwmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/3j+skZ6UtW+5u09lHNsj6tQ51s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZwIDAQAB",
+  "creation_date": "30-06-2015T 14:52:35+00.00"
+}

--- a/tests/mock-api/delete-block-storage.json
+++ b/tests/mock-api/delete-block-storage.json
@@ -1,0 +1,18 @@
+{
+  "id": "6AD2F180B7B666539EF75A02FE227084",
+  "size": 200,
+  "state": "REMOVING",
+  "description": "My block storage for containers",
+  "datacenter": {
+    "id": "D0F6D8C8ED29D3036F94C27BBB7BAD36",
+    "location": "USA",
+    "country_code": "US"
+  },
+  "name": "My block storage 1",
+  "creation_date": "2015-05-06T08:33:25+00:00",
+  "server":
+  {
+    "id": "638ED28205B1AFD7ADEF569C725DD85F",
+    "name": "My server 1"
+  }
+}

--- a/tests/mock-api/detach-block-storage.json
+++ b/tests/mock-api/detach-block-storage.json
@@ -1,0 +1,14 @@
+{
+  "id": "6AD2F180B7B666539EF75A02FE227084",
+  "size": 200,
+  "state": "CONFIGURING",
+  "description": "My block storage description",
+  "datacenter": {
+    "id": "D0F6D8C8ED29D3036F94C27BBB7BAD36",
+    "location": "USA",
+    "country_code": "US"
+  },
+  "name": "My block storage 4",
+  "creation_date": "2015-05-06T08:33:25+00:00",
+  "server": null
+}

--- a/tests/mock-api/get-block-storage.json
+++ b/tests/mock-api/get-block-storage.json
@@ -1,0 +1,18 @@
+{
+  "id": "6AD2F180B7B666539EF75A02FE227084",
+  "size": 200,
+  "state": "ACTIVE",
+  "description": "My block storage for containers",
+  "datacenter": {
+    "id": "D0F6D8C8ED29D3036F94C27BBB7BAD36",
+    "location": "USA",
+    "country_code": "US"
+  },
+  "name": "My block storage 1",
+  "creation_date": "2015-05-06T08:33:25+00:00",
+  "server":
+  {
+    "id": "638ED28205B1AFD7ADEF569C725DD85F",
+    "name": "My server 1"
+  }
+}

--- a/tests/mock-api/get-ssh-key.json
+++ b/tests/mock-api/get-ssh-key.json
@@ -1,0 +1,13 @@
+{
+  "id": "39AA65F5D5B02FA02D58173094EBAF95",
+  "name": "My SSH key 1",
+  "description": "My SSH key description",
+  "state": "ACTIVE",
+  "servers": [
+	{"id": "D0F6D8C8ED29D3036F94C27BBB789536","name": "Server 1"},
+	{"id": "E0F6D8C8ED29D3036F94C27BBB789537","name": "Server 2"}
+  ],
+  "md5": "5df9f63916ebf8528697b629022993e8",
+  "public_key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUpwmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/3j+skZ6UtW+5u09lHNsj6tQ51s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZwIDAQAB",
+  "creation_date": "30-06-2015T 14:52:35+00.00"
+}

--- a/tests/mock-api/list-block-storages.json
+++ b/tests/mock-api/list-block-storages.json
@@ -1,0 +1,52 @@
+[
+{
+  "id": "6AD2F180B7B666539EF75A02FE227084",
+  "size": 200,
+  "state": "ACTIVE",
+  "description": "My block storage for containers",
+  "datacenter": {
+    "id": "D0F6D8C8ED29D3036F94C27BBB7BAD36",
+    "location": "USA",
+    "country_code": "US"
+  },
+  "name": "My block storage 1",
+  "creation_date": "2015-05-06T08:33:25+00:00",
+  "server":
+  {
+    "id": "638ED28205B1AFD7ADEF569C725DD85F",
+    "name": "My server 1"
+  }
+},
+{
+  "id": "4406CE4723BB441C7956E25C51CE8C1B",
+  "size": 50,
+  "state": "ACTIVE",
+  "description": "My block storage description",
+  "datacenter": {
+    "id": "D0F6D8C8ED29D3036F94C27BBB7BAD36",
+    "location": "USA",
+    "country_code": "US"
+  },
+  "name": "My block storage 3",
+  "creation_date": "2015-03-17T11:57:48+00:00",
+  "server": null
+},
+{
+  "id": "1A5418172DD3BD39F8010A6633F1018A",
+  "size": 250,
+  "state": "ACTIVE",
+  "description": "",
+  "datacenter": {
+    "id": "D0F6D8C8ED29D3036F94C27BBB7BAD36",
+    "location": "USA",
+    "country_code": "US"
+  },
+  "name": "My block storage 2",
+  "creation_date": "2015-05-05T09:36:31+00:00",
+  "server":
+  {
+    "id": "748ED28205B1AFD7ADEF569C725DD85E",
+    "name": "My server 2"
+  }
+}
+]

--- a/tests/mock-api/list-ssh-keys.json
+++ b/tests/mock-api/list-ssh-keys.json
@@ -1,0 +1,28 @@
+[
+{
+  "id": "39AA65F5D5B02FA02D58173094EBAF95",
+  "name": "My SSH key 1",
+  "description": "My SSH key description",
+  "state": "ACTIVE",
+  "servers": [
+	{"id": "D0F6D8C8ED29D3036F94C27BBB789536","name": "Server 1"},
+	{"id": "E0F6D8C8ED29D3036F94C27BBB789537","name": "Server 2"}
+  ],
+  "md5": "5df9f63916ebf8528697b629022993e8",
+  "public_key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUpwmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/3j+skZ6UtW+5u09lHNsj6tQ51s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZwIDAQAB",
+  "creation_date": "30-06-2015T 14:52:35+00.00"
+},
+{
+  "id": "39AA65F5D5B02FA02D58173094EBAF96",
+  "name": "My SSH key 2",
+  "description": "My SSH key description",
+  "state": "ACTIVE",
+  "servers": [
+	{"id": "D0F6D8C8ED29D3036F94C27BBB789536","name": "Server 1"},
+	{"id": "E0F6D8C8ED29D3036F94C27BBB789537","name": "Server 2"}
+  ],
+  "md5": "5df9f63916ebf8528697b629022993e3",
+  "public_key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUpwmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/3j+skZ6UtW+5u09lHNsj6tQ51s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZwIDAQAC",
+  "creation_date": "31-08-2017T 14:52:35+00.00"
+}
+]

--- a/tests/mock-api/modify-block-storage.json
+++ b/tests/mock-api/modify-block-storage.json
@@ -1,0 +1,18 @@
+{
+  "id": "6AD2F180B7B666539EF75A02FE227084",
+  "size": 200,
+  "state": "CONFIGURING",
+  "description": "New Desc",
+  "datacenter": {
+    "id": "D0F6D8C8ED29D3036F94C27BBB7BAD36",
+    "location": "USA",
+    "country_code": "US"
+  },
+  "name": "New Name",
+  "creation_date": "2015-05-06T08:33:25+00:00",
+  "server":
+  {
+    "id": "638ED28205B1AFD7ADEF569C725DD85F",
+    "name": "My server 1"
+  }
+}

--- a/tests/mock-api/modify-ssh-key.json
+++ b/tests/mock-api/modify-ssh-key.json
@@ -1,0 +1,13 @@
+{
+  "id": "39AA65F5D5B02FA02D58173094EBAF95",
+  "name": "My SSH key 1 updated",
+  "description": "My SSH key description updated",
+  "state": "ACTIVE",
+  "servers": [
+	{"id": "D0F6D8C8ED29D3036F94C27BBB789536","name": "Server 1"},
+	{"id": "E0F6D8C8ED29D3036F94C27BBB789537","name": "Server 2"}
+  ],
+  "md5": "5df9f63916ebf8528697b629022993e8",
+  "public_key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUpwmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/3j+skZ6UtW+5u09lHNsj6tQ51s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZwIDAQAB",
+  "creation_date": "30-06-2015T 14:52:35+00.00"
+}

--- a/tests/mock-api/remove-ssh-key.json
+++ b/tests/mock-api/remove-ssh-key.json
@@ -1,0 +1,13 @@
+{
+  "id": "39AA65F5D5B02FA02D58173094EBAF95",
+  "name": "My SSH key 1 updated",
+  "description": "My SSH key description updated",
+  "state": "DELETING",
+  "servers": [
+	{"id": "D0F6D8C8ED29D3036F94C27BBB789536","name": "Server 1"},
+	{"id": "E0F6D8C8ED29D3036F94C27BBB789537","name": "Server 2"}
+  ],
+  "md5": "5df9f63916ebf8528697b629022993e8",
+  "public_key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUpwmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/3j+skZ6UtW+5u09lHNsj6tQ51s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZwIDAQAB",
+  "creation_date": "30-06-2015T 14:52:35+00.00"
+}

--- a/tests/sshkeymock.php
+++ b/tests/sshkeymock.php
@@ -1,0 +1,118 @@
+<?php
+
+require_once(dirname(__DIR__).'/src/oneandone/ssh_key.php');
+
+class SshKeyTest extends PHPUnit_Framework_TestCase
+{
+
+    public function setup() {
+
+        $this->stub = $this->getMockBuilder('src\oneandone\SshKey')
+                     ->disableOriginalConstructor()
+                     ->getMock();
+
+    }
+
+    public function testAll() {
+
+        // Read mock JSON data
+        $file = file_get_contents('tests/mock-api/list-ssh-keys.json');
+        $data = json_decode($file, true);
+
+        // Create stub
+        $this->stub->method('all')
+             ->willReturn($data);
+
+        // Perform call
+        $res = $this->stub->all();
+
+        // Assert
+        $this->assertEquals($res[0]['id'], '39AA65F5D5B02FA02D58173094EBAF95');
+
+    }
+
+    public function testCreate() {
+
+        // Read mock JSON data
+        $file = file_get_contents('tests/mock-api/create-ssh-key.json');
+        $data = json_decode($file, true);
+
+        // Create stub
+        $this->stub->method('create')
+             ->willReturn($data);
+
+        // Perform call
+        $specs = [
+            'name' => 'My SSH key 1',
+            'description' => 'My SSH key description',
+            'public_key' => 'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUpwmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/3j+skZ6UtW+5u09lHNsj6tQ51s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZwIDAQAB'
+        ];
+
+        $res = $this->stub->create($specs);
+
+        // Assert
+        $this->assertEquals($res['id'], '39AA65F5D5B02FA02D58173094EBAF95');
+
+    }
+
+    public function testGet() {
+
+        // Read mock JSON data
+        $file = file_get_contents('tests/mock-api/get-ssh-key.json');
+        $data = json_decode($file, true);
+
+        // Create stub
+        $this->stub->method('get')
+             ->willReturn($data);
+
+        // Perform call
+        $res = $this->stub->get('39AA65F5D5B02FA02D58173094EBAF95');
+
+        // Assert
+        $this->assertEquals($res['id'], '39AA65F5D5B02FA02D58173094EBAF95');
+
+    }
+
+    public function testModify() {
+
+        // Read mock JSON data
+        $file = file_get_contents('tests/mock-api/modify-ssh-key.json');
+        $data = json_decode($file, true);
+
+        // Create stub
+        $this->stub->method('modify')
+             ->willReturn($data);
+
+        // Perform call
+        $specs = [
+            'name' => 'My SSH key 1 updated',
+            'description' => 'My SSH key description updated'
+        ];
+
+        $res = $this->stub->modify($specs, '39AA65F5D5B02FA02D58173094EBAF95');
+
+        // Assert
+        $this->assertEquals($res['id'], '39AA65F5D5B02FA02D58173094EBAF95');
+        $this->assertEquals($res['name'], 'My SSH key 1 updated');
+
+    }
+
+    public function testDelete() {
+
+        // Read mock JSON data
+        $file = file_get_contents('tests/mock-api/remove-ssh-key.json');
+        $data = json_decode($file, true);
+
+        // Create stub
+        $this->stub->method('delete')
+             ->willReturn($data);
+
+        // Perform call
+        $res = $this->stub->delete('39AA65F5D5B02FA02D58173094EBAF95');
+
+        // Assert
+        $this->assertEquals($res['state'], 'DELETING');
+
+    }
+
+}


### PR DESCRIPTION
Added support for API releases 1.7, 1.8, and 1.9 (custom image import, ssh keys, block storage). Documentation, examples, and mock tests included).